### PR TITLE
fix(icons): no dynamic resolution in icons

### DIFF
--- a/libs/icons/package.json
+++ b/libs/icons/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://cws-cares.netlify.com",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
-  "module": "dist/index.module.js",
+  "module": "dist/index.es.js",
   "directories": {
     "lib": "dist",
     "test": "src/__tests__"
@@ -20,16 +20,7 @@
   "scripts": {
     "test": "jest",
     "prebuild": "rimraf dist",
-    "build": "run-p build:es",
-    "build:es": "babel src --out-dir dist --ignore \"src/**/*.stories.js\",\"src/**/*.test.js\",\"__tests__\"",
-    "build:cjs": "rollup src/index.js -c rollup.config.js --format cjs --file dist/index.cjs.js",
-    "build:css": "node-sass -r -o dist --source-map true --importer ../../node_modules/node-sass-tilde-importer/index.js src",
-    "prebuild:watch": "rimraf dist",
-    "build:watch": "run-p build:watch:*",
-    "build:watch:es": "yarn build:es -w",
-    "//build:watch:css": "run-p build:watch:css:*",
-    "//build:watch:css:deps": "onchange '../core/scss/**/*.scss' -- yarn build:css",
-    "//build:watch:css:self": "yarn build:css && yarn build:css -w"
+    "build": "rollup src/index.js -c rollup.config.js"
   },
   "dependencies": {
     "@cwds/core": "^0.3.7",

--- a/libs/icons/rollup.config.js
+++ b/libs/icons/rollup.config.js
@@ -1,0 +1,51 @@
+import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
+import babel from 'rollup-plugin-babel'
+import pkg from './package.json'
+
+const externals = depsBlacklist(pkg)
+
+export default [
+  {
+    input: 'src/index.js',
+    output: [
+      {
+        file: pkg.main,
+        format: 'cjs',
+        exports: 'named',
+        sourcemap: true,
+      },
+      {
+        file: pkg.module,
+        format: 'es',
+        sourcemap: true,
+      },
+    ],
+    external: id => {
+      if (externals.includes(id)) return true
+      if (/module\.s?css$/.test(id)) return true
+      return false
+    },
+    plugins: [
+      resolve({
+        extensions: ['.js', '.jsx'],
+      }),
+      commonjs(),
+      babel({
+        babelrc: false,
+        exclude: 'node_modules/**',
+        presets: [['babel-preset-env', { modules: false }]],
+        plugins: [
+          'transform-class-properties',
+          'transform-object-rest-spread',
+          'transform-react-jsx',
+          'external-helpers',
+        ],
+      }),
+    ],
+  },
+]
+
+function depsBlacklist({ dependencies = {}, peerDependencies = {} }) {
+  return [...Object.keys(dependencies), ...Object.keys(peerDependencies)]
+}

--- a/libs/icons/src/Icon.jsx
+++ b/libs/icons/src/Icon.jsx
@@ -2,10 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import DS from '@cwds/core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import loadIcons from './icon-library'
-
-// Side Effect
-loadIcons()
 
 const Icon = props => {
   const { name, icon, color, themeColors, ...restProps } = props

--- a/libs/icons/src/icon-library.js
+++ b/libs/icons/src/icon-library.js
@@ -1,36 +1,51 @@
 import { library } from '@fortawesome/fontawesome-svg-core'
+import {
+  faArrowUp,
+  faBell,
+  faCheck,
+  faCheckCircle,
+  faChevronDown,
+  faCircleNotch,
+  faClipboard,
+  faClock,
+  faCog,
+  faEllipsisV,
+  faExclamationTriangle,
+  faExternalLinkAlt,
+  faFlag,
+  faInfoCircle,
+  faMapMarkerAlt,
+  faPrint,
+  faSearch,
+  faTimes,
+  faUpload,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons'
 
-const ICONS = [
-  'faArrowUp',
-  'faBell',
-  'faCheck',
-  'faCheckCircle',
-  'faChevronDown',
-  'faCircleNotch',
-  'faClipboard',
-  'faClock',
-  'faCog',
-  'faEllipsisV',
-  'faExclamationTriangle',
-  'faExternalLinkAlt',
-  'faFlag',
-  'faInfoCircle',
-  'faMapMarkerAlt',
-  'faPrint',
-  'faSearch',
-  'faTimes',
-  'faUpload',
-  'faUser',
-]
+library.add(
+  faArrowUp,
+  faBell,
+  faCheck,
+  faCheckCircle,
+  faChevronDown,
+  faCircleNotch,
+  faClipboard,
+  faClock,
+  faCog,
+  faEllipsisV,
+  faExclamationTriangle,
+  faExternalLinkAlt,
+  faFlag,
+  faInfoCircle,
+  faMapMarkerAlt,
+  faPrint,
+  faSearch,
+  faTimes,
+  faUpload,
+  faUser
+)
 
-const { iconPack, iconNames: ICON_NAMES } = loadIcons(ICONS)
-
-// Seed Icon Library
-export default () => {
-  library.add(iconPack)
-}
-
-export { ICON_NAMES }
+export const ICON_NAMES = Object.keys(library.definitions['fas'])
 
 export const getIconFromContext = context => {
   switch (context) {
@@ -44,15 +59,4 @@ export const getIconFromContext = context => {
     default:
       return false
   }
-}
-
-function loadIcons(icons) {
-  const iconPack = {}
-  let iconNames = []
-  icons.forEach(name => {
-    const mod = require(`@fortawesome/free-solid-svg-icons/${name}`)
-    iconPack[name] = mod.definition
-    iconNames.push(mod.iconName)
-  })
-  return { iconPack, iconNames }
 }


### PR DESCRIPTION
Accomplishes 2 things:

* [x] fix missing es/cjs build for `@cwds/icons` (probably the cause of #232 and #233)
* [x] use plain 'ol es6 imports for icons instead of `require`s w/i a loop construct