### PR TITLE
feat(components): add Tile component

### DIFF
--- a/apps/www/src/modules/components/articles/ReactDogenInfo.js
+++ b/apps/www/src/modules/components/articles/ReactDogenInfo.js
@@ -27,4 +27,5 @@ export default {
     '@cwds/components/src/Layouts/Page/Page.jsx',
     '@cwds/components/src/Layouts/Page/Page.props'
   ),
+  Tile: docgenComposed('@cwds/components/src/Tile/Tile.jsx'),
 }

--- a/apps/www/src/modules/components/articles/Tile/Tile.mdx
+++ b/apps/www/src/modules/components/articles/Tile/Tile.mdx
@@ -1,6 +1,8 @@
 import { Tile } from "@cwds/components";
 import TileExample from "./TileExample";
+import TileGroupExample from "./TileGroupExample";
 import { PropTable, DemoCard } from "@cwds/docs";
+import Docgen from "../ReactDogenInfo.js";
 
 ## Synopsis
 
@@ -14,6 +16,10 @@ The `Tile` is a great component.
 import { Tile } from "@cwds/%LIBRARY_NAME%";
 ```
 
+<DemoCard>
+  <TileGroupExample />
+</DemoCard>
+
 <!--
 ### Optional Supporting Section
 
@@ -22,7 +28,7 @@ Additional introductory section or a gallery if there exist a wide range of inst
 
 ## Props
 
-<!--<PropTable docgen={Docgen["Tile"]} />-->
+<PropTable docgen={Docgen["Tile"]} />
 
 ## Usage Guidelines
 

--- a/apps/www/src/modules/components/articles/Tile/Tile.mdx
+++ b/apps/www/src/modules/components/articles/Tile/Tile.mdx
@@ -1,24 +1,31 @@
-import { Tile } from "@cwds/components";
+import { Fragment } from "react";
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  CardTitle,
+  Tile,
+  TileGroup,
+  TilePlaceholder,
+  Icon,
+  MenuItem
+} from "@cwds/components";
 import TileExample from "./TileExample";
 import TileGroupExample from "./TileGroupExample";
-import { PropTable, DemoCard } from "@cwds/docs";
+import { PropTable, DemoCard, ReferenceCard } from "@cwds/docs";
 import Docgen from "../ReactDogenInfo.js";
 
 ## Synopsis
 
-The `Tile` is a great component.
+`Tile`s are used in <dfn>Summary View</dfn>s (typically preceeding the general <dfn>Collection View</dfn>). `Tile`s are typically found in groupds of two to three in a `TileGroup` atop a `CardBody`.
 
 <DemoCard>
   <TileExample />
 </DemoCard>
 
 ```jsx
-import { Tile } from "@cwds/%LIBRARY_NAME%";
+import { Tile } from "@cwds/components";
 ```
-
-<DemoCard>
-  <TileGroupExample />
-</DemoCard>
 
 <!--
 ### Optional Supporting Section
@@ -32,20 +39,152 @@ Additional introductory section or a gallery if there exist a wide range of inst
 
 ## Usage Guidelines
 
-DOs & DONTs
+The intended use case for `Tile`s, are for _at a glance_ summaries.
 
 ### Content Guidelines
 
-### Accessibility
+The `Tile`'s title should be short and to the point. Text overflow is is truncated to two lines of content. Please limit the length of titles.
+
+<!-- ### Accessibility -->
 
 ## Examples
 
-<!--
+### Default
+
+No `Icon` or `Menu` is present by default:
+
+<DemoCard>
+  <Tile title="Basic Tile">I am just content...</Tile>
+</DemoCard>
+
+```jsx
+<Tile title="Basic Tile">I am just content...</Tile>
+```
+
+### with Icon
+
+Use the `icon` prop to add an `Icon` to a tile:
+
+<DemoCard>
+  <Tile icon="check" title="Some Title">
+    Totally sweet content here
+  </Tile>
+</DemoCard>
+
+```jsx
+<Tile icon="check" title="Some Title">
+  Totally sweet content here
+</Tile>
+```
+
+The `Tile` component also accepts an `Icon` prop if you need more control of the `Icon`. You should try to avoid using this form however. We risk introducing variability this way.
+
+<DemoCard>
+  <Tile title="Some Title" Icon={<Icon name="comment-alt" set="far" />}>
+    Totally sweet content here
+  </Tile>
+</DemoCard>
+
+### with Menu
+
+`Tile`s can have <dfn>Contextual Menu</dfn>s too!
+
+<DemoCard>
+  <Tile
+    title="With Menu"
+    MenuItems={
+      <Fragment>
+        <MenuItem>Foo</MenuItem>
+        <MenuItem>Bar</MenuItem>
+        <MenuItem>Quo</MenuItem>
+      </Fragment>
+    }
+  >
+    This <code>Tile</code> has a <code>Menu</code>. <em>Awesome!</em>
+  </Tile>
+</DemoCard>
+
+```jsx
+<Tile
+  title="With Menu"
+  MenuItems={
+    <Fragment>
+      <MenuItem>Foo</MenuItem>
+      <MenuItem>Bar</MenuItem>
+      <MenuItem>Quo</MenuItem>
+    </Fragment>
+  }
+>
+  This <code>Tile</code> has a <code>Menu</code>. <em>Awesome!</em>
+</Tile>
+```
+
+### with `TileGroup` in a `Card`
+
+`Tile`s are seldom encountered in isolation. CARES uses `TileGroup`s for summary views. The `TileGroup` behaves exactly like `CardDeck` (because it uses the `CardDeck` component). `Tile`s should generally be wrapped in the `TileGroup` so that sibling `Tile`s have the same height.
+
+<DemoCard>
+  <TileGroupExample />
+</DemoCard>
+
+```jsx
+import {
+  Tile,
+  TileGroup,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody
+} from "@cwds/components";
+
+<Card>
+  <CardHeader>
+    <CardTitle>Chores</CardTitle>
+  </CardHeader>
+  <CardBody>
+    <TileGroup>
+      <Tile {...props} />
+      <Tile {...props} />
+      <Tile {...props} />
+    </TileGroup>
+  </CardBody>
+</Card>;
+```
+
+<!-- this needs more work (e.g.; TilePlaceholders shouldn't render in flat views)
+### Placeholder Tile
+
+In order for `Tile` widths within a `TileGroup` to be consistent, the _number_ of `Tile`s present in a particular use case should be consistent (whether data exists for them or not).
+
+Consider a `TileGroup` which may represent your 3-most-recent conversations... On first use, there will be zero conversations at all! This is an appropriate use case for the `TilePlaceholder`:
+
+<DemoCard>
+  <Card>
+    <CardHeader>
+      <CardTitle>Chores</CardTitle>
+    </CardHeader>
+    <CardBody>
+      <TileGroup>
+        <Tile title="Foo">
+          I am a normal <code>Tile</code>
+        </Tile>
+        <TilePlaceholder>PLACEHOLDER</TilePlaceholder>
+        <TilePlaceholder>PLACEHOLDER</TilePlaceholder>
+      </TileGroup>
+    </CardBody>
+  </Card>
+</DemoCard>
+-->
 
 ## Related Articles
 
+<!--
 ### Patterns
+-->
 
 ### Components
 
--->
+- [`Card`](/components/card)
+- [`CardDeck`](/components/card-deck)
+- [`TileGroup`](/components/tile-group)
+- [`TilePlaceholder`](/components/tile-placeholder)

--- a/apps/www/src/modules/components/articles/Tile/Tile.mdx
+++ b/apps/www/src/modules/components/articles/Tile/Tile.mdx
@@ -1,0 +1,45 @@
+import { Tile } from "@cwds/components";
+import TileExample from "./TileExample";
+import { PropTable, DemoCard } from "@cwds/docs";
+
+## Synopsis
+
+The `Tile` is a great component.
+
+<DemoCard>
+  <TileExample />
+</DemoCard>
+
+```jsx
+import { Tile } from "@cwds/%LIBRARY_NAME%";
+```
+
+<!--
+### Optional Supporting Section
+
+Additional introductory section or a gallery if there exist a wide range of instances that should be shown (e.g.; IconGallery)
+-->
+
+## Props
+
+<!--<PropTable docgen={Docgen["Tile"]} />-->
+
+## Usage Guidelines
+
+DOs & DONTs
+
+### Content Guidelines
+
+### Accessibility
+
+## Examples
+
+<!--
+
+## Related Articles
+
+### Patterns
+
+### Components
+
+-->

--- a/apps/www/src/modules/components/articles/Tile/TileExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileExample.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import {
+  Tile,
+  UncontrolledMenu as Menu,
+  MenuItem,
+  Icon,
+} from '@cwds/components'
+
+const MyMenu = (
+  <Menu right>
+    <MenuItem>Profile</MenuItem>
+    <MenuItem>Schedule Meeting</MenuItem>
+    <MenuItem>Report Issue</MenuItem>
+  </Menu>
+)
+
+const TileExample = () => (
+  <Tile
+    title="The Tile Title which could potentially be really really long"
+    foo="foo"
+    bar="bar"
+    quo="quo"
+    Menu={MyMenu}
+    Icon={<Icon name="check" />}
+  >
+    Just some content... I am just a container so pretty much anything can be
+    put in me
+  </Tile>
+)
+
+export default TileExample

--- a/apps/www/src/modules/components/articles/Tile/TileExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileExample.jsx
@@ -22,6 +22,7 @@ const TileExample = () => (
     quo="quo"
     Menu={MyMenu}
     Icon={<Icon name="check" />}
+    className="mb-0"
   >
     Just some content... I am just a container so pretty much anything can be
     put in me

--- a/apps/www/src/modules/components/articles/Tile/TileExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileExample.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import {
   Tile,
   UncontrolledMenu as Menu,
@@ -14,13 +14,29 @@ const MyMenu = (
   </Menu>
 )
 
+const MyMenuItemsFragment = (
+  <Fragment>
+    <MenuItem>Profile</MenuItem>
+    <MenuItem>Schedule Meeting</MenuItem>
+    <MenuItem>Report Issue</MenuItem>
+  </Fragment>
+)
+
+const MyMenuItemsArray = [
+  <MenuItem key="profile">Profile</MenuItem>,
+  <MenuItem key="meeting">Schedule Meeting</MenuItem>,
+  <MenuItem key="issue">Report Issue</MenuItem>,
+]
+
 const TileExample = () => (
   <Tile
     title="The Tile Title which could potentially be really really long"
     foo="foo"
     bar="bar"
     quo="quo"
-    Menu={MyMenu}
+    // Menu={MyMenu}
+    MenuItems={MyMenuItemsFragment}
+    // MenuItems={MyMenuItemsArray}
     Icon={<Icon name="check" />}
     className="mb-0"
   >

--- a/apps/www/src/modules/components/articles/Tile/TileExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileExample.jsx
@@ -1,18 +1,18 @@
 import React, { Fragment } from 'react'
 import {
   Tile,
-  UncontrolledMenu as Menu,
+  // UncontrolledMenu as Menu,
   MenuItem,
-  Icon,
+  // Icon,
 } from '@cwds/components'
 
-const MyMenu = (
-  <Menu right>
-    <MenuItem>Profile</MenuItem>
-    <MenuItem>Schedule Meeting</MenuItem>
-    <MenuItem>Report Issue</MenuItem>
-  </Menu>
-)
+// const MyMenu = (
+//   <Menu right>
+//     <MenuItem>Profile</MenuItem>
+//     <MenuItem>Schedule Meeting</MenuItem>
+//     <MenuItem>Report Issue</MenuItem>
+//   </Menu>
+// )
 
 const MyMenuItemsFragment = (
   <Fragment>
@@ -22,22 +22,18 @@ const MyMenuItemsFragment = (
   </Fragment>
 )
 
-const MyMenuItemsArray = [
-  <MenuItem key="profile">Profile</MenuItem>,
-  <MenuItem key="meeting">Schedule Meeting</MenuItem>,
-  <MenuItem key="issue">Report Issue</MenuItem>,
-]
+// const MyMenuItemsArray = [
+//   <MenuItem key="profile">Profile</MenuItem>,
+//   <MenuItem key="meeting">Schedule Meeting</MenuItem>,
+//   <MenuItem key="issue">Report Issue</MenuItem>,
+// ]
 
 const TileExample = () => (
   <Tile
-    title="The Tile Title which could potentially be really really long"
-    foo="foo"
-    bar="bar"
-    quo="quo"
-    // Menu={MyMenu}
+    title="I am a Tile"
     MenuItems={MyMenuItemsFragment}
     // MenuItems={MyMenuItemsArray}
-    Icon={<Icon name="check" />}
+    icon="check"
     className="mb-0"
   >
     Just some content... I am just a container so pretty much anything can be

--- a/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardDeck,
+  CardHeader,
+  CardTitle,
+  Col,
+  MenuItem,
+  Row,
+  Tile,
+  UncontrolledMenu as Menu,
+} from '@cwds/components'
+
+const TileGroupExample = () => (
+  <Card className="mb-0">
+    <CardHeader>
+      <CardTitle>Chores</CardTitle>
+    </CardHeader>
+    <CardBody>
+      <CardDeck>
+        <Tile
+          icon="exclamation-triangle"
+          title="Pay Bills"
+          Menu={
+            <Menu right size="sm">
+              <MenuItem>Autopay Settings</MenuItem>
+              <MenuItem>Ignore</MenuItem>
+              <MenuItem>One-Time Payment</MenuItem>
+            </Menu>
+          }
+        >
+          Just some content... I am just a container so pretty much anything can
+          be put in me
+        </Tile>
+        <Tile
+          icon="check"
+          title="Take Out Trash, but with an excessively long title"
+        >
+          Not much to see here
+        </Tile>
+        <Tile
+          icon="bell"
+          title="Approve Changes"
+          Menu={
+            <Menu right size="sm">
+              <MenuItem>Approve</MenuItem>
+              <MenuItem>Edit Workflow</MenuItem>
+              <MenuItem>Vacation</MenuItem>
+            </Menu>
+          }
+        >
+          <div className="my-1">
+            <Link to="/">Important Document</Link>
+          </div>
+          <div className="mb-1">
+            <div>
+              <small>Last Edit:</small>
+              <small className="float-right">
+                <Link to="/">5m ago</Link>
+              </small>
+            </div>
+            <div>
+              <small>By:</small>
+              <small className="float-right">
+                <Link to="/">John Smith</Link>
+              </small>
+            </div>
+            <div>
+              <small>Labels:</small>
+              <small className="float-right">
+                <Badge color="success">Foo</Badge>{' '}
+                <Badge color="warning">Bar</Badge>{' '}
+                <Badge color="danger">Quo</Badge>
+              </small>
+            </div>
+            <Row>
+              <Col>
+                <small>Recommendation:</small>
+              </Col>
+              <Col className="text-right">
+                <small>
+                  <Link to="/">Approve</Link>
+                </small>
+              </Col>
+            </Row>
+          </div>
+        </Tile>
+      </CardDeck>
+    </CardBody>
+  </Card>
+)
+
+export default TileGroupExample

--- a/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
@@ -46,7 +46,7 @@ const TileGroupExample = () => (
           icon="bell"
           title="Approve Changes"
           Menu={
-            <Menu right size="sm">
+            <Menu right>
               <MenuItem>Approve</MenuItem>
               <MenuItem>Edit Workflow</MenuItem>
               <MenuItem>Vacation</MenuItem>

--- a/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
+++ b/apps/www/src/modules/components/articles/Tile/TileGroupExample.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import {
   Badge,
-  Button,
   Card,
   CardBody,
   CardDeck,

--- a/apps/www/src/modules/components/routes.js
+++ b/apps/www/src/modules/components/routes.js
@@ -19,6 +19,7 @@ import TooltipPage from '!babel-loader!@mdx-js/loader!./articles/Tooltip/Tooltip
 import Modal from '!babel-loader!@mdx-js/loader!./articles/Modal/Modal.mdx'
 import Page from '!babel-loader!@mdx-js/loader!./articles/Page/Page.mdx'
 import CaresProvider from '!babel-loader!@mdx-js/loader!./articles/CaresProvider/CaresProvider.mdx'
+import Tile from '!babel-loader!@mdx-js/loader!./articles/Tile/Tile.mdx'
 
 const routes = {
   title: 'Component Library',
@@ -76,6 +77,11 @@ const routes = {
       //     component: () => <div>TODO</div>,
       //   },
       // ],
+    },
+    {
+      title: 'Tile',
+      path: '/tile',
+      component: Tile,
     },
     // {
     //   title: 'CheckboxBank',

--- a/libs/components/src/Menu/Menu.jsx
+++ b/libs/components/src/Menu/Menu.jsx
@@ -78,7 +78,7 @@ function getDropdownToggleProps(props) {
     )
   }
   return {
-    ...pick(props, Object.keys(DropdownToggle.propTypes)),
+    ...pick(props, [...Object.keys(DropdownToggle.propTypes), 'size']),
     caret: false,
     children,
   }

--- a/libs/components/src/Menu/Menu.test.js
+++ b/libs/components/src/Menu/Menu.test.js
@@ -53,4 +53,14 @@ describe('Menu', () => {
     )
     expect(wrapper.find(Arrow).length).toBe(1)
   })
+
+  it('passes the `size` prop to DropdownToggle', () => {
+    const wrapper = shallow(
+      <Menu size="sm">
+        <MenuItem>Foo</MenuItem>
+        <MenuItem>Bar</MenuItem>
+      </Menu>
+    )
+    expect(wrapper.find(DropdownToggle).prop('size')).toBe('sm')
+  })
 })

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -55,3 +55,5 @@ Tile.propTypes = {
 Tile.defaultProps = {}
 
 export default Tile
+
+const TilePlaceholder = () => <Card>alksdfj</Card>

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -4,12 +4,14 @@ import cn from 'classnames'
 import { Card, CardBody, CardHeader, CardTitle } from '@cwds/reactstrap'
 import { Icon } from '@cwds/icons'
 import { grays } from '@cwds/core'
+import { UncontrolledMenu as Menu } from '../Menu'
 import Styles from './Tile.module.scss'
 
 const Tile = ({
   children,
   className,
   Menu: ProvidedMenu,
+  MenuItems,
   icon,
   Icon: ProvidedIcon,
   title,
@@ -22,6 +24,13 @@ const Tile = ({
       className: cn(ProvidedIcon.props.className || '', 'mr-2'),
     })
   )
+  const menu = MenuItems ? (
+    <Menu size="sm" right>
+      {MenuItems}
+    </Menu>
+  ) : (
+    ProvidedMenu
+  )
   return (
     <Card className={cn(className)}>
       <CardHeader className="border-bottom-0 pb-0 d-flex justify-content-between">
@@ -31,7 +40,7 @@ const Tile = ({
             {title}
           </CardTitle>
         </div>
-        {ProvidedMenu}
+        {menu}
       </CardHeader>
       <CardBody>{children}</CardBody>
     </Card>
@@ -45,8 +54,13 @@ Tile.propTypes = {
   icon: PropTypes.string,
   /** Longform notation for icon declaration */
   Icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  /** Pass a Menu react node or component */
+  /** Pass a Menu react node or component. Use the `MenuItems` when possible. */
   Menu: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  /** Pass MenuItems to render a Tile menu. Does not render a Menu by default */
+  MenuItems: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
   /** String shorthand for Title declaration */
   title: PropTypes.string,
   /** Longform notation for Title declaration */
@@ -55,5 +69,3 @@ Tile.propTypes = {
 Tile.defaultProps = {}
 
 export default Tile
-
-const TilePlaceholder = () => <Card>alksdfj</Card>

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -1,5 +1,41 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames'
+import { Card, CardBody, CardHeader, CardTitle } from '@cwds/reactstrap'
 
-const Tile = () => <div />
+const Tile = ({ children, className, Menu, Icon, title }) => {
+  return (
+    <Card className={cn(className)}>
+      <CardHeader className="border-bottom-0 p-2 d-flex justify-content-between">
+        <div
+          className="flex-grow-1"
+          style={{
+            maxHeight: '4rem',
+            overflowY: 'hidden',
+          }}
+        >
+          <CardTitle>
+            {Icon &&
+              React.cloneElement(Icon, {
+                className: cn(Icon.props.className, 'mr-2'),
+              })}
+            {title}
+          </CardTitle>
+        </div>
+        {Menu}
+      </CardHeader>
+      <CardBody className="p-2">{children}</CardBody>
+    </Card>
+  )
+}
+
+Tile.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  Menu: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  title: PropTypes.string,
+  Title: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+}
+Tile.defaultProps = {}
 
 export default Tile

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -2,27 +2,36 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 import { Card, CardBody, CardHeader, CardTitle } from '@cwds/reactstrap'
+import { Icon } from '@cwds/icons'
+import { grays } from '@cwds/core'
+import Styles from './Tile.module.scss'
 
-const Tile = ({ children, className, Menu, Icon, title }) => {
+const Tile = ({
+  children,
+  className,
+  Menu: ProvidedMenu,
+  icon,
+  Icon: ProvidedIcon,
+  title,
+}) => {
+  const TileIcon = icon ? (
+    <Icon name={icon} className="mr-2" color={grays['700']} />
+  ) : (
+    ProvidedIcon &&
+    React.cloneElement(ProvidedIcon, {
+      className: cn(ProvidedIcon.props.className || '', 'mr-2'),
+    })
+  )
   return (
     <Card className={cn(className)}>
-      <CardHeader className="border-bottom-0 p-2 d-flex justify-content-between">
-        <div
-          className="flex-grow-1"
-          style={{
-            maxHeight: '4rem',
-            overflowY: 'hidden',
-          }}
-        >
+      <CardHeader className="border-bottom-0 pb-0 px-2 pt-2 d-flex justify-content-between">
+        <div className={cn('flex-grow-1', Styles.TitleContainer)}>
           <CardTitle>
-            {Icon &&
-              React.cloneElement(Icon, {
-                className: cn(Icon.props.className, 'mr-2'),
-              })}
+            {TileIcon}
             {title}
           </CardTitle>
         </div>
-        {Menu}
+        {ProvidedMenu}
       </CardHeader>
       <CardBody className="p-2">{children}</CardBody>
     </Card>
@@ -32,8 +41,15 @@ const Tile = ({ children, className, Menu, Icon, title }) => {
 Tile.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  /** String shorthand for icon declaration */
+  icon: PropTypes.string,
+  /** Longform notation for icon declaration */
+  Icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  /** Pass a Menu react node or component */
   Menu: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  /** String shorthand for Title declaration */
   title: PropTypes.string,
+  /** Longform notation for Title declaration */
   Title: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 }
 Tile.defaultProps = {}

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const Tile = () => <div />
+
+export default Tile

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -24,7 +24,7 @@ const Tile = ({
   )
   return (
     <Card className={cn(className)}>
-      <CardHeader className="border-bottom-0 pb-0 px-2 pt-2 d-flex justify-content-between">
+      <CardHeader className="border-bottom-0 pb-0 d-flex justify-content-between">
         <div className={cn('flex-grow-1', Styles.TitleContainer)}>
           <CardTitle>
             {TileIcon}
@@ -33,7 +33,7 @@ const Tile = ({
         </div>
         {ProvidedMenu}
       </CardHeader>
-      <CardBody className="p-2">{children}</CardBody>
+      <CardBody>{children}</CardBody>
     </Card>
   )
 }

--- a/libs/components/src/Tile/Tile.jsx
+++ b/libs/components/src/Tile/Tile.jsx
@@ -22,6 +22,7 @@ const Tile = ({
     ProvidedIcon &&
     React.cloneElement(ProvidedIcon, {
       className: cn(ProvidedIcon.props.className || '', 'mr-2'),
+      color: grays['700'],
     })
   )
   const menu = MenuItems ? (
@@ -50,9 +51,9 @@ const Tile = ({
 Tile.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-  /** String shorthand for icon declaration */
+  /** String shorthand (preferred) for Icon declaration */
   icon: PropTypes.string,
-  /** Longform notation for icon declaration */
+  /** Longform notation for Icon declaration. Use the `icon` prop when possible */
   Icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /** Pass a Menu react node or component. Use the `MenuItems` when possible. */
   Menu: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),

--- a/libs/components/src/Tile/Tile.module.scss
+++ b/libs/components/src/Tile/Tile.module.scss
@@ -1,0 +1,4 @@
+.TitleContainer {
+  max-height: 3.5rem;
+  overflow-y: hidden;
+}

--- a/libs/components/src/Tile/Tile.module.scss
+++ b/libs/components/src/Tile/Tile.module.scss
@@ -1,4 +1,8 @@
+@import "~@cwds/core/scss/base";
+
+$MAX_NUM_LINES: 2;
+
 .TitleContainer {
-  max-height: 3.5rem;
+  max-height: ($h3-font-size + $spacer / 2) * $MAX_NUM_LINES;
   overflow-y: hidden;
 }

--- a/libs/components/src/Tile/Tile.test.js
+++ b/libs/components/src/Tile/Tile.test.js
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { shallow } from 'enzyme'
 import { CardTitle } from '@cwds/reactstrap'
 import { Icon } from '@cwds/icons'
 import Tile from './Tile'
+import { UncontrolledMenu as Menu, MenuItem } from '../Menu'
 
 describe('Tile', () => {
   it('renders', () => {
@@ -23,5 +24,40 @@ describe('Tile', () => {
     const wrapper = shallow(<Tile title="my title" />)
     expect(wrapper.find(CardTitle).length).toBe(1)
     expect(wrapper.find(CardTitle).prop('children')).toContain('my title')
+  })
+
+  it('does not render a Menu by default', () => {
+    const wrapper = shallow(<Tile />)
+    expect(wrapper.find(Menu).length).toBe(0)
+  })
+
+  describe('MenuItems prop', () => {
+    it('accepts a react node', () => {
+      const wrapper = shallow(
+        <Tile
+          MenuItems={
+            <Fragment>
+              <MenuItem>Foo</MenuItem>
+              <MenuItem>Bar</MenuItem>
+              <MenuItem>Quo</MenuItem>
+            </Fragment>
+          }
+        />
+      )
+      expect(wrapper.find(MenuItem).length).toBe(3)
+    })
+
+    it('accepts an array of react nodes', () => {
+      const wrapper = shallow(
+        <Tile
+          MenuItems={[
+            <MenuItem key="foo">Foo</MenuItem>,
+            <MenuItem key="bar">Bar</MenuItem>,
+            <MenuItem key="quo">Quo</MenuItem>,
+          ]}
+        />
+      )
+      expect(wrapper.find(MenuItem).length).toBe(3)
+    })
   })
 })

--- a/libs/components/src/Tile/Tile.test.js
+++ b/libs/components/src/Tile/Tile.test.js
@@ -1,9 +1,27 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import { CardTitle } from '@cwds/reactstrap'
+import { Icon } from '@cwds/icons'
 import Tile from './Tile'
 
 describe('Tile', () => {
   it('renders', () => {
     expect(() => shallow(<Tile />)).not.toThrow()
+  })
+
+  it('accepts a string icon prop', () => {
+    const wrapper = shallow(<Tile icon="foo" />)
+    expect(wrapper.find(Icon).prop('name')).toBe('foo')
+  })
+
+  it('accepts an Icon declaration', () => {
+    const wrapper = shallow(<Tile Icon={<Icon name="my-icon" />} />)
+    expect(wrapper.find(Icon).length).toBe(1)
+  })
+
+  it('accepts a string title', () => {
+    const wrapper = shallow(<Tile title="my title" />)
+    expect(wrapper.find(CardTitle).length).toBe(1)
+    expect(wrapper.find(CardTitle).prop('children')).toContain('my title')
   })
 })

--- a/libs/components/src/Tile/Tile.test.js
+++ b/libs/components/src/Tile/Tile.test.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Tile from './Tile'
+
+describe('Tile', () => {
+  it('renders', () => {
+    expect(() => shallow(<Tile />)).not.toThrow()
+  })
+})

--- a/libs/components/src/Tile/TileGroup.jsx
+++ b/libs/components/src/Tile/TileGroup.jsx
@@ -1,0 +1,1 @@
+export { CardDeck as default } from '@cwds/reactstrap'

--- a/libs/components/src/Tile/TileGroup.test.js
+++ b/libs/components/src/Tile/TileGroup.test.js
@@ -1,0 +1,8 @@
+import TileGroup from './TileGroup'
+
+describe('TileGroup', () => {
+  it('is defined', () => {
+    expect(TileGroup).toBeDefined()
+    expect(typeof TileGroup).toBe('function')
+  })
+})

--- a/libs/components/src/Tile/TilePlaceholder.jsx
+++ b/libs/components/src/Tile/TilePlaceholder.jsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <div />

--- a/libs/components/src/Tile/TilePlaceholder.jsx
+++ b/libs/components/src/Tile/TilePlaceholder.jsx
@@ -1,3 +1,4 @@
 import React from 'react'
+import { Card } from '@cwds/reactstrap'
 
-export default () => <div />
+export default props => <Card {...props} />

--- a/libs/components/src/Tile/TilePlaceholder.test.js
+++ b/libs/components/src/Tile/TilePlaceholder.test.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import TilePlaceholder from './Tile'
+
+describe('TilePlaceholder', () => {
+  it('renders', () => {
+    expect(() => shallow(<TilePlaceholder />)).not.toThrow()
+  })
+})

--- a/libs/components/src/Tile/index.js
+++ b/libs/components/src/Tile/index.js
@@ -1,1 +1,3 @@
-export { default } from './Tile'
+export { default as Tile } from './Tile'
+export { default as TileGroup } from './TileGroup'
+export { default as TilePlaceholder } from './TilePlaceholder'

--- a/libs/components/src/Tile/index.js
+++ b/libs/components/src/Tile/index.js
@@ -1,0 +1,1 @@
+export { default } from './Tile'

--- a/libs/components/src/Tile/index.test.js
+++ b/libs/components/src/Tile/index.test.js
@@ -1,0 +1,14 @@
+import * as Exports from './index'
+
+// Any failures here should be a breaking change
+
+describe('Tile module', () => {
+  it.each`
+    component
+    ${'Tile'}
+    ${'TilePlaceholder'}
+    ${'TileGroup'}
+  `('exports $component', ({ component }) => {
+    expect(Exports[component]).toBeDefined()
+  })
+})

--- a/libs/components/src/index.js
+++ b/libs/components/src/index.js
@@ -32,3 +32,4 @@ export {
 export { default as RadioGroup } from './RadioGroup'
 export { Utils }
 export { CaresContext, default as CaresProvider } from './utils/CaresContext'
+export { default as Tile } from './Tile'

--- a/libs/components/src/index.js
+++ b/libs/components/src/index.js
@@ -32,4 +32,4 @@ export {
 export { default as RadioGroup } from './RadioGroup'
 export { Utils }
 export { CaresContext, default as CaresProvider } from './utils/CaresContext'
-export { default as Tile } from './Tile'
+export { Tile, TileGroup, TilePlaceholder } from './Tile'

--- a/libs/reactstrap/src/index.js
+++ b/libs/reactstrap/src/index.js
@@ -5,7 +5,6 @@
  *   - Alert
  *   - CardBlock
  *   - CardColumns
- *   - CardDeck
  *   - CardGroup
  *   - CardImg
  *   - CardImgOverlay
@@ -53,6 +52,7 @@ export {
   ButtonToolbar,
   Card,
   CardBody,
+  CardDeck,
   CardFooter,
   CardHeader,
   Col,


### PR DESCRIPTION
https://osi-cwds.atlassian.net/browse/CL-41 

* [x] Finish docs
* [x] Design Review
* [x] Add `TileGroup`, `TilePlaceholder`
* [x] Usage Guidelines?
* [x] use `$spacer[3]` (default) for padding
* [x] use `[size="sm"]` for `DropdownToggle`
* [x] use scss vars to compute `max-height` (overflow)
* [x] accept `MenuItems` so we can abstract the `IconMenu` formation from app devs
* [x] ~Implement a simple `TilePlaceholder`~

NO `TilePlaceholder`, needs more thought. Out of scope.

<img width="877" alt="screen shot 2019-02-12 at 10 50 24 pm" src="https://user-images.githubusercontent.com/30477263/52692393-a1b19080-2f18-11e9-8b1f-2616287b9753.png">
