### PR TITLE
fix(datagrid): fix flex layout bug for IE

### DIFF
--- a/libs/datagrid/src/DataGrid.module.scss
+++ b/libs/datagrid/src/DataGrid.module.scss
@@ -54,7 +54,6 @@
         text-align: left;
       }
       .-center {
-        flex: 0;
         @include media-breakpoint-down(sm) {
           flex: auto;
         }


### PR DESCRIPTION
This PR will fix the [CL-99](https://osi-cwds.atlassian.net/browse/CL-99) bug.

The flex for IE is partially supported.

Before the Fix :

<img width="1367" alt="screen shot 2019-02-26 at 11 35 20 am" src="https://user-images.githubusercontent.com/30814092/53442740-ce58b400-39be-11e9-810f-2bef6ed97b4c.png">

After the fix: 

<img width="1356" alt="screen shot 2019-02-26 at 11 36 31 am" src="https://user-images.githubusercontent.com/30814092/53442758-d7e21c00-39be-11e9-928d-0e696314a32e.png">
