### PR TITLE
fix(components): Fix react-select to open top when no space bottom.

### DIFF
--- a/libs/datagrid/src/Pagination.jsx
+++ b/libs/datagrid/src/Pagination.jsx
@@ -140,6 +140,7 @@ class Pagination extends Component {
                 onChange={({ value }) => onPageSizeChange(Number(value))}
                 clearable={false}
                 searchable={false}
+                menuPlacement="auto"
               />
             </div>
           )}


### PR DESCRIPTION
This fixes the bug react-select from thrashing the footer.

Before:

![bug-react-select](https://user-images.githubusercontent.com/30814094/53823360-77a32b00-3f26-11e9-91b4-826bef8b5abd.gif)

After:

![fix-react-select](https://user-images.githubusercontent.com/30814094/53823411-95709000-3f26-11e9-909a-6a09dd9b6e35.gif)


[Preview Deploy](https://deploy-preview-65--cws-cares.netlify.com/components/datagrid/basic-search)