### PR TITLE
chore(www): Add toggles demo (#486)

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,6 +11,7 @@
     "formik": "^1.3.1",
     "jest-dom": "^3.0.0",
     "lodash.get": "^4.4.2",
+    "lodash.pick": "^4.4.0",
     "lodash.set": "^4.3.2",
     "react": "^16.4",
     "react-dom": "^16.4",

--- a/apps/www/src/App.js
+++ b/apps/www/src/App.js
@@ -17,6 +17,7 @@ import ReassessmentForm from './demos/ReassessmentForm'
 import MessageArea from './demos/MesssageArea'
 import PageTemplates from './examples/PageTemplates'
 import CardHeaderDemo from './demos/CardHeaders'
+import ToggleDemos from './demos/ToggleDemos'
 
 class App extends Component {
   render() {
@@ -42,6 +43,7 @@ class App extends Component {
                 />
                 <Route path="/demo/message-area" component={MessageArea} />
                 <Route path="/demo/card-header" component={CardHeaderDemo} />
+                <Route path="/demo/toggles" component={ToggleDemos} />
                 <Route
                   path="/__examples__/page-templates"
                   component={PageTemplates}

--- a/apps/www/src/demos/ToggleDemos.js
+++ b/apps/www/src/demos/ToggleDemos.js
@@ -1,0 +1,137 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import pick from 'lodash.pick'
+import {
+  Alert,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  ButtonGroup,
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  Col,
+  Page,
+  Row,
+} from '@cwds/components'
+
+class ToggleRadios extends Component {
+  static defaultProps = {
+    options: [
+      { value: 'foo', label: 'Foo' },
+      { value: 'bar', label: 'Bar' },
+      { value: 'quo', label: 'Quo' },
+    ],
+    color: 'secondary',
+    size: undefined,
+    outline: undefined,
+    onChange: () => {},
+  }
+
+  handleClick = e => {
+    this.props.onChange(e.target.value)
+  }
+
+  render() {
+    const buttonProps = pick(this.props, ['color', 'size', 'outline'])
+    return (
+      <ButtonGroup>
+        {this.props.options.map(option => {
+          return (
+            <Button
+              key={option.value}
+              {...buttonProps}
+              value={option.value}
+              onClick={this.handleClick}
+              active={option.value === this.props.value}
+            >
+              {option.label}
+            </Button>
+          )
+        })}
+      </ButtonGroup>
+    )
+  }
+}
+
+export class ToggleDemos extends Component {
+  combinations = [
+    ['default', {}],
+    ['outline', { outline: true }],
+    ['color="primary"', { color: 'primary' }],
+    ['color="primary" outline', { color: 'primary', outline: true }],
+    ['color="primary" size="sm"', { color: 'primary', size: 'sm' }],
+    ['color="primary" size="lg"', { color: 'primary', size: 'lg' }],
+  ]
+  state = {
+    radioValue: undefined,
+    value2: undefined,
+  }
+  handleRadioChange = radioValue => {
+    this.setState({ radioValue })
+  }
+  render() {
+    return (
+      <Page
+        title="Toggles"
+        Breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbItem>
+              <Link to="/">Home</Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem>Demos</BreadcrumbItem>
+            <BreadcrumbItem active>Toggles</BreadcrumbItem>
+          </Breadcrumb>
+        }
+      >
+        <div>
+          <Card>
+            <CardHeader>
+              <CardTitle>Toggles</CardTitle>
+            </CardHeader>
+            <CardBody>
+              <Row className="mb-2">
+                <Col sm={2}>Props</Col>
+                <Col>Toggle</Col>
+                <Col>Button</Col>
+              </Row>
+              {this.combinations.map(([name, props], index) => {
+                return (
+                  <Row key={index} className="mb-2">
+                    <Col sm={2}>{name}</Col>
+                    <Col>
+                      <ToggleRadios
+                        value={this.state.radioValue}
+                        onChange={this.handleRadioChange}
+                        {...props}
+                      />
+                    </Col>
+                    <Col>
+                      <Button {...props}>Button</Button>{' '}
+                      <Button {...props} active>
+                        Active
+                      </Button>{' '}
+                      <Button {...props} disabled>
+                        Disabled
+                      </Button>
+                    </Col>
+                  </Row>
+                )
+              })}
+            </CardBody>
+          </Card>
+        </div>
+        <Alert color="warning">
+          <strong>Note</strong>: Keyboard navigability <em>should</em> depend on
+          whether or not the control behaves as a <code>radio group</code>.
+          Example: There should be a keyboard context and the arrow keys SHOULD
+          work for radio groups... Here, we take a little shortcut. OK for
+          non-forms, but useage as a form field control is NOT recommended.
+        </Alert>
+      </Page>
+    )
+  }
+}
+
+export default ToggleDemos


### PR DESCRIPTION
Adds the `/demo/toggles` route to show how basic Toggles look w/o making any changes to our design system or overriding reactstrap components.